### PR TITLE
fix(ci): add branch config for semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,15 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
+  "release": {
+    "branches": [
+      "main",
+      {
+        "name": "beta",
+        "prerelease": true
+      }
+    ]
+  },
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",
     "@commitlint/config-conventional": "^16.2.1",


### PR DESCRIPTION
the defaults no longer work, so added explicitly
